### PR TITLE
fix:  missing MemData map keys on OS X (closes #2)

### DIFF
--- a/src/http_cache_store_disk_stats.erl
+++ b/src/http_cache_store_disk_stats.erl
@@ -36,6 +36,8 @@ system_memory_use() ->
     system_memory_use(maps:from_list(
                           memsup:get_system_memory_data())).
 
+system_memory_use(#{free_memory := Free, system_total_memory := Total}) ->
+    1 - Free / Total;
 system_memory_use(#{available_memory := Available, system_total_memory := Total}) ->
     1 - Available / Total;
 system_memory_use(MemData) ->


### PR DESCRIPTION
Fixes a crash at boot on Mac OS X. The documentation of :memsup warns keys in the resulting map may come an go and that they are platform dependent.

```
[error] GenServer :http_cache_store_disk_lru_nuker_memory terminating
** (KeyError) key :cached_memory not found in: %{
  system_total_memory: **redacted**,
  free_memory: **redacted**,
  total_memory: **redacted**
}
```